### PR TITLE
Moved code of conduct link in Contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Awesome lists about Internationalization & localization stuff. T9n, l10n, g11n, 
 - [Tools](#tools)
 - [Articles](#articles)
 - [Other](#other)
-- [Code of Conduct](#code-of-conduct)
 
 ## Translations
 
@@ -71,8 +70,4 @@ Awesome lists about Internationalization & localization stuff. T9n, l10n, g11n, 
 
 ## Contributing
 
-Warmly welcome! Kindly go through [Contribution Guidelines](CONTRIBUTING.md) first.
-
-## Code of Conduct
-
-See [Code of Conduct](CODE-OF-CONDUCT.md).
+Warmly welcome! Kindly go through [Contribution Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE-OF-CONDUCT.md) first.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome Translations [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
 
-Awesome lists about Internationalization & localization stuff. T9n, l10n, g11n, m17n, i18n.
+Tools to help with localization & translation (T9n, l10n, g11n, m17n, i18n).
 
 ## Contents
 


### PR DESCRIPTION
Removed Code of Conduct title and moved the link in Contributing to follow the awesome guidelines