### PR TITLE
Added Respresso to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This list contains tools, books, articles, blogs, courses and everything related
 - [Zanata](http://zanata.org/) - Web-based translation platform for translators, content creators and developers to manage localisation projects.
 - [Traduora](https://github.com/traduora/traduora) - A platform for manage translation workflow in teams.
 - [SimpleLocalize](https://simplelocalize.io) - A simple translation management for software projects.
+- [Respresso](https://respresso.io/) - Let your whole team edit resource files (localizations and translations, images, colors, etc.) with Respresso’s online editor to get them in a platform-specific format, automatically delivered to your source code.
 
 ## Apps
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This list contains tools, books, articles, blogs, courses and everything related
 - [Zanata](http://zanata.org/) - Web-based translation platform for translators, content creators and developers to manage localisation projects.
 - [Traduora](https://github.com/traduora/traduora) - A platform for manage translation workflow in teams.
 - [SimpleLocalize](https://simplelocalize.io) - A simple translation management for software projects.
-- [Respresso](https://respresso.io/) - Let your whole team edit resource files (localizations and translations, images, colors, etc.) with Respresso’s online editor to get them in a platform-specific format, automatically delivered to your source code.
+- [Respresso](https://respresso.io/) - Collaborative online resource manager for localizations, images, colors, etc. that generates platform-specific files and delivers them directly to your source code.
 
 ## Apps
 


### PR DESCRIPTION
To clarify:
- I'm one of the developers from the Respresso team.
- Respresso is a commercial project, but it is currently free, without ads or limitations. 
- In the future, we'll have an always-free tier for small projects. (As far as I can tell, without feature limitations, only quantity limits.)
- Respresso is not a translation only tool, it is a collaborative resource editor supporting multiple platforms, including localizations and their translations.

Most of the business logic is provided by the backend, our clients are “build-time” file downloader tools for automation.
