### PR TITLE
Add Respresso in context translation article to the awesome-translations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This list contains tools, books, articles, blogs, courses and everything related
 - [Approaches to Machine Translation](http://engineering.fuoye.edu.ng/journal/index.php/engineer/article/view/26/pdf) - A paper-review on different techniques for machine translation.
 - [Neural Machine Translation](https://jair.org/index.php/jair/article/view/12007/26611) - A paper-review that trace back the origins of modern NMT architectures to word and sentence embeddings and earlier examples of the encoder-decoder network family. It will conclude with a short survey of more recent trends in the field.
 - [What is 'hreflang'?](https://simplelocalize.io/blog/posts/what-is-hreflang/) - What is `hreflang` attribute and how it can affect your SERP.
+- [In context translation with Respresso](https://blog.respresso.io/index.php/2020/06/22/in-context-translation-with-respresso/) - Real-time preview how the translations will look like in your mobile app or web. No need to wait for the next deployment.
 
 ## Blogs
 


### PR DESCRIPTION
To clarify:
- I'm one of the developers from the Respresso team.
- Respresso is a commercial project, but it is currently free, without ads or limitations. 
- In the future, we'll have an always-free tier for small projects. (As far as I can tell, without feature limitations, only quantity limits.)
- Respresso is not a translation only tool, it is a collaborative resource editor supporting multiple platforms, including localizations and their translations.

Most of the business logic is provided by the backend, our clients are “build-time” file downloader tools for automation.
