### PR TITLE
Add sphinx-intl

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This list contains tools, books, articles, blogs, courses and everything related
 - [Django docs - i18n](https://docs.djangoproject.com/en/4.1/topics/i18n/) - Part of the Django docs, focused on internationalization and localization.
 - [Localizejs](https://localizejs.com/) - Translations for websites and applications to new languages and streamline translation workflow.
 - [ParaglideJS](https://inlang.com/m/gerre34r) - Synchronous, typesafe and lightweight i18n library.
+- [sphinx-intl](https://github.com/sphinx-doc/sphinx-intl) - A Sphinx utility that make it easy to translate and to apply translations.
 
 ### Machine translation for developers
 - [SwiftGoogleTranslate](https://github.com/maximbilan/SwiftGoogleTranslate) - A framework to use cloud translation API by Google in Swift.


### PR DESCRIPTION
``sphinx-intl`` is a utility tool that provides several features that make it easy to translate and to apply translation to Sphinx_ generated document. Optional: support the Transifex service for translation with Sphinx.