### PR TITLE
Add ScreenTranslate to Other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This list contains tools, books, articles, blogs, courses and everything related
 - [Globalize](https://github.com/globalizejs/globalize) - A JavaScript library for internationalization and localization that leverage the official Unicode CLDR JSON data.
 - [SimpleLocalize CLI](https://github.com/simplelocalize/simplelocalize-cli) - A CLI for finding translation keys in project files.
 - [Ninja i18n](https://inlang.com/m/3gk8n4n4/app-inlang-ninjaI18nAction) - A GitHub action for translation linting in pull requests.
+- [ScreenTranslate](https://screentranslate.filient.ai/) - A free macOS menu bar app that translates any text on your screen via area capture (OCR) or text selection, fully on-device.
 
 ## Articles
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This list contains tools, books, articles, blogs, courses and everything related
 - [Crow Translate](https://github.com/crow-translate/crow-translate) - A simple and lightweight translator for Linux and Windows that allows to translate and speak text using Google, Yandex and Bing translate API.
 - [Copy Translator](https://github.com/CopyTranslator/CopyTranslator) - An app for Windows, Mac and Linux that automatically translate and adapt a text when copied in the clipboard.
 - [LibreTranslate](https://github.com/uav4geo/LibreTranslate) - 100% Self-Hosted web app to translate text, based on Argos Translate.
+- [ScreenTranslate](https://github.com/hcmhcs/screenTranslate) - A free macOS menu bar app that translates any text on your screen via area capture (OCR) or text selection, fully on-device.
 
 ### Translation software
 - [OmegaT](https://omegat.org/) - Free translation memory / CAT software that works on Windows, macOS and Linux.
@@ -111,7 +112,6 @@ This list contains tools, books, articles, blogs, courses and everything related
 - [Globalize](https://github.com/globalizejs/globalize) - A JavaScript library for internationalization and localization that leverage the official Unicode CLDR JSON data.
 - [SimpleLocalize CLI](https://github.com/simplelocalize/simplelocalize-cli) - A CLI for finding translation keys in project files.
 - [Ninja i18n](https://inlang.com/m/3gk8n4n4/app-inlang-ninjaI18nAction) - A GitHub action for translation linting in pull requests.
-- [ScreenTranslate](https://screentranslate.filient.ai/) - A free macOS menu bar app that translates any text on your screen via area capture (OCR) or text selection, fully on-device.
 
 ## Articles
 


### PR DESCRIPTION
## What is ScreenTranslate?

[ScreenTranslate](https://screentranslate.filient.ai/) is a free, open-source macOS menu bar app that translates any text on your screen.

- Capture any area for OCR-based translation, or select text directly in any app
- Fully on-device via Apple Vision + Apple Translation — no servers, no tracking
- 20 languages with auto-detect, works offline
- GPL-3.0

GitHub: https://github.com/hcmhcs/screenTranslate
Website: https://screentranslate.filient.ai

### Checklist
- [x] I have read the CONTRIBUTING guide
- [x] Added in the Other tools section
- [x] Follows the existing format
- [x] Open-source (GPL-3.0 License)